### PR TITLE
[Level 1-2] 코드 추가 퀴즈 - JWT 의 이해

### DIFF
--- a/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
+++ b/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
@@ -36,11 +36,12 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        // JwtFilter 에서 set 한 userId, email, userRole 값을 가져옴
+        // JwtFilter 에서 set 한 userId, email, userRole, nickname 값을 가져옴
         Long userId = (Long) request.getAttribute("userId");
         String email = (String) request.getAttribute("email");
         UserRole userRole = UserRole.of((String) request.getAttribute("userRole"));
+        String nickname = (String) request.getAttribute("nickname");
 
-        return new AuthUser(userId, email, userRole);
+        return new AuthUser(userId, email, userRole, nickname);
     }
 }

--- a/src/main/java/org/example/expert/config/JwtFilter.java
+++ b/src/main/java/org/example/expert/config/JwtFilter.java
@@ -60,6 +60,7 @@ public class JwtFilter implements Filter {
             httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
             httpRequest.setAttribute("email", claims.get("email"));
             httpRequest.setAttribute("userRole", claims.get("userRole"));
+            httpRequest.setAttribute("nickname", claims.get("nickname"));
 
             if (url.startsWith("/admin")) {
                 // 관리자 권한이 없는 경우 403을 반환합니다.

--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -34,7 +34,7 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, UserRole userRole) {
+    public String createToken(Long userId, String email, UserRole userRole, String nickname) {
         Date date = new Date();
 
         return BEARER_PREFIX +
@@ -42,6 +42,7 @@ public class JwtUtil {
                         .setSubject(String.valueOf(userId))
                         .claim("email", email)
                         .claim("userRole", userRole)
+                        .claim("nickname", nickname)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘

--- a/src/main/java/org/example/expert/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/expert/domain/auth/dto/request/SignupRequest.java
@@ -2,6 +2,7 @@ package org.example.expert.domain.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,4 +18,12 @@ public class SignupRequest {
     private String password;
     @NotBlank
     private String userRole;
+
+    // nickname 조건
+    // 최소 1자에서 최대 16자
+    // 한글, 영어, 숫자, 하나의 공백만 허용
+    // 연속된 공백 두 개 이상은 비허용
+    @NotBlank   // null 과 ""(초기화된 String), " "(공백) 모두 비허용
+    @Pattern(regexp = "^(?!.*\\s{2,})[a-zA-Z0-9가-힣\\s]{1,16}$", message = "닉네임 형식이 올바르지 않습니다.")
+    private String nickname;
 }

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -38,11 +38,12 @@ public class AuthService {
         User newUser = new User(
                 signupRequest.getEmail(),
                 encodedPassword,
-                userRole
+                userRole,
+                signupRequest.getNickname()
         );
         User savedUser = userRepository.save(newUser);
 
-        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), userRole);
+        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), userRole, savedUser.getNickname());
 
         return new SignupResponse(bearerToken);
     }
@@ -56,7 +57,7 @@ public class AuthService {
             throw new AuthException("잘못된 비밀번호입니다.");
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getUserRole());
+        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getUserRole(), user.getNickname());
 
         return new SigninResponse(bearerToken);
     }

--- a/src/main/java/org/example/expert/domain/common/dto/AuthUser.java
+++ b/src/main/java/org/example/expert/domain/common/dto/AuthUser.java
@@ -9,10 +9,12 @@ public class AuthUser {
     private final Long id;
     private final String email;
     private final UserRole userRole;
+    private final String nickname;
 
-    public AuthUser(Long id, String email, UserRole userRole) {
+    public AuthUser(Long id, String email, UserRole userRole, String nickname) {
         this.id = id;
         this.email = email;
         this.userRole = userRole;
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/org/example/expert/domain/user/entity/User.java
+++ b/src/main/java/org/example/expert/domain/user/entity/User.java
@@ -32,14 +32,15 @@ public class User extends Timestamped {
         this.nickname = nickname;
     }
 
-    private User(Long id, String email, UserRole userRole) {
+    private User(Long id, String email, UserRole userRole,String nickname) {
         this.id = id;
         this.email = email;
         this.userRole = userRole;
+        this.nickname = nickname;
     }
 
     public static User fromAuthUser(AuthUser authUser) {
-        return new User(authUser.getId(), authUser.getEmail(), authUser.getUserRole());
+        return new User(authUser.getId(), authUser.getEmail(), authUser.getUserRole(), authUser.getNickname());
     }
 
     public void changePassword(String password) {

--- a/src/main/java/org/example/expert/domain/user/entity/User.java
+++ b/src/main/java/org/example/expert/domain/user/entity/User.java
@@ -21,10 +21,15 @@ public class User extends Timestamped {
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
-    public User(String email, String password, UserRole userRole) {
+    // 기획자의 긴급 요청
+    // nickname - 중복 가능
+    private String nickname;
+
+    public User(String email, String password, UserRole userRole, String nickname) {
         this.email = email;
         this.password = password;
         this.userRole = userRole;
+        this.nickname = nickname;
     }
 
     private User(Long id, String email, UserRole userRole) {


### PR DESCRIPTION
## JWT 의 이해

### User
- User 테이블에 nickname 컬럼 추가
  - nickname 은 중복 가능

- AuthUser 에 nickname 정보 추가에 따른 User 의 fromAuthUser 메서드 내 User 생성자 파라미터 수정

### JwtUtil & JwtFilter
- JWT 에 nickname 클레임 추가

### SignupRequest
- [Bean Validation] SignUpRequest DTO 의 nickname 조건

- nickname 조건
  - 최소 1자에서 최대 16자
  - 한글, 영어, 숫자, 하나의 공백만 허용
  - 연속된 공백 두 개 이상은 비허용

### AuthUserArgumentResolver
- JwtFilter 에서 추가 set 한 nickname 값 가져오기 추가

### AuthUser
- 인증된 유저 AuthUser 에도 nickname 정보 추가

### AuthService
- SignUpRequest DTO 의 nickname 필드 추가에 따른 signup 메서드 내 User 생성자 파라미터 변경
- JWT 에 nickname 클레임 추가