### PR TITLE
[Level 2-7] N+1 문제

### DIFF
--- a/src/main/java/org/example/expert/domain/comment/entity/Comment.java
+++ b/src/main/java/org/example/expert/domain/comment/entity/Comment.java
@@ -7,6 +7,9 @@ import org.example.expert.domain.common.entity.Timestamped;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.user.entity.User;
 
+// [Level 2-7] N+1 문제
+// 3. @NamedEntityGraph
+//@NamedEntityGraph(name = "Comment.findAll", attributeNodes = @NamedAttributeNode("user"))
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.comment.repository;
 
 import org.example.expert.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,22 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c JOIN c.user WHERE c.todo.id = :todoId")
+//    @Query("SELECT c FROM Comment c JOIN c.user WHERE c.todo.id = :todoId")
+//    List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
+
+    // 1. Fetch Join
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.todo.id = :todoId")
     List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
+
+    // 2. @EntityGraph
+//    @EntityGraph(attributePaths = {"user"})
+//    @EntityGraph(attributePaths = {"user"}, type = EntityGraph.EntityGraphType.LOAD)
+//    @Query("SELECT c FROM Comment c WHERE c.todo.id = :todoId")
+//    List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
+
+    // 3. @NamedEntityGraph
+//    @EntityGraph("Comment.findAll")
+//    @EntityGraph(value = "Comment.findAll", type = EntityGraph.EntityGraphType.LOAD)
+//    @Query("SELECT c FROM Comment c WHERE c.todo.id = :todoId")
+//    List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
 }


### PR DESCRIPTION
## N+1 문제

### 발생 원인

- 연관 관계에 있는 User Entity를 사용할 때, N개의 select 쿼리가 추가 발생하여 N+1 문제가 발생

### 해결 방법

1. Fetch Join

3. EntityGraph

4. NamedEntityGraph